### PR TITLE
Refactor SubjectEqualsPredicate

### DIFF
--- a/src/main/java/seedu/address/model/person/Subject.java
+++ b/src/main/java/seedu/address/model/person/Subject.java
@@ -39,6 +39,14 @@ public class Subject {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if this subject is the same as the other subject, ignoring case.
+     */
+    public boolean isSameSubject(Subject otherSubject) {
+        requireNonNull(otherSubject);
+        return subject.equalsIgnoreCase(otherSubject.subject);
+    }
+
     @Override
     public String toString() {
         return subject;

--- a/src/main/java/seedu/address/model/person/SubjectEqualsPredicate.java
+++ b/src/main/java/seedu/address/model/person/SubjectEqualsPredicate.java
@@ -14,7 +14,7 @@ public class SubjectEqualsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return person.getSubject().subject.equalsIgnoreCase(subject.subject);
+        return person.getSubject().isSameSubject(subject);
     }
 
     @Override
@@ -26,6 +26,6 @@ public class SubjectEqualsPredicate implements Predicate<Person> {
             return false;
         }
         SubjectEqualsPredicate otherPredicate = (SubjectEqualsPredicate) other;
-        return subject.subject.equalsIgnoreCase(otherPredicate.subject.subject);
+        return subject.isSameSubject(otherPredicate.subject);
     }
 }


### PR DESCRIPTION
This PR partially addresses #83.

- Refactored SubjectEqualsPredicate to improve encapsulation
  - Extracted comparison logic into Subject#isSameSubject
  - Removed direct access to internal field