### PR TITLE
Refactor FindCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -27,51 +27,73 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = tokenizeAndValidate(args);
+
+        if (hasName(argMultimap)) {
+            return parseName(argMultimap);
+        }
+
+        if (hasSubject(argMultimap)) {
+            return parseSubject(argMultimap);
+        }
+
+        return parseRate(argMultimap);
+    }
+
+    private ArgumentMultimap tokenizeAndValidate(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_RATE, PREFIX_SUBJECT);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_RATE, PREFIX_SUBJECT);
 
-        boolean hasName = argMultimap.getValue(PREFIX_NAME).isPresent();
-        boolean hasRate = argMultimap.getValue(PREFIX_RATE).isPresent();
-        boolean hasSubject = argMultimap.getValue(PREFIX_SUBJECT).isPresent();
-
-        int prefixCount = 0;
-        if (hasName) {
-            prefixCount++;
-        }
-        if (hasRate) {
-            prefixCount++;
-        }
-        if (hasSubject) {
-            prefixCount++;
-        }
-
-        if (!argMultimap.getPreamble().isEmpty() || prefixCount != 1) {
+        if (!isValidFindInput(argMultimap)) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (hasName) {
-            String nameArgs = argMultimap.getValue(PREFIX_NAME).get().trim();
+        return argMultimap;
+    }
 
-            if (nameArgs.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-
-            String[] nameKeywords = nameArgs.split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    private boolean isValidFindInput(ArgumentMultimap argMultimap) {
+        if (!argMultimap.getPreamble().isEmpty()) {
+            return false;
         }
 
-        if (hasSubject) {
-            String subjectArgs = argMultimap.getValue(PREFIX_SUBJECT).get().trim();
-
-            if (subjectArgs.isEmpty() || !Subject.isValidSubject(subjectArgs)) {
-                throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
-            }
-
-            return new FindCommand(new SubjectEqualsPredicate(new Subject(subjectArgs)));
+        int prefixCount = 0;
+        if (hasName(argMultimap)) {
+            prefixCount++;
+        }
+        if (hasRate(argMultimap)) {
+            prefixCount++;
+        }
+        if (hasSubject(argMultimap)) {
+            prefixCount++;
         }
 
+        return prefixCount == 1;
+    }
+
+    private FindCommand parseName(ArgumentMultimap argMultimap) throws ParseException {
+        String nameArgs = argMultimap.getValue(PREFIX_NAME).get().trim();
+
+        if (nameArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = nameArgs.split("\\s+");
+        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    private FindCommand parseSubject(ArgumentMultimap argMultimap) throws ParseException {
+        String subjectArgs = argMultimap.getValue(PREFIX_SUBJECT).get().trim();
+
+        if (subjectArgs.isEmpty() || !Subject.isValidSubject(subjectArgs)) {
+            throw new ParseException(Subject.MESSAGE_CONSTRAINTS);
+        }
+
+        return new FindCommand(new SubjectEqualsPredicate(new Subject(subjectArgs)));
+    }
+
+    private FindCommand parseRate(ArgumentMultimap argMultimap) throws ParseException {
         String rateArgs = argMultimap.getValue(PREFIX_RATE).get().trim();
 
         if (rateArgs.isEmpty() || !Rate.isValidRate(rateArgs)) {
@@ -79,5 +101,17 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         return new FindCommand(new RateEqualsPredicate(new Rate(rateArgs)));
+    }
+
+    private boolean hasName(ArgumentMultimap argMultimap) {
+        return argMultimap.getValue(PREFIX_NAME).isPresent();
+    }
+
+    private boolean hasRate(ArgumentMultimap argMultimap) {
+        return argMultimap.getValue(PREFIX_RATE).isPresent();
+    }
+
+    private boolean hasSubject(ArgumentMultimap argMultimap) {
+        return argMultimap.getValue(PREFIX_SUBJECT).isPresent();
     }
 }


### PR DESCRIPTION
Refactored FindCommandParser to improve SLAP by extracting validation and prefix-specific parsing into helper methods.

No functional changes intended.
Existing parsing behaviour for name, subject, and rate prefixes is preserved.

Partially fixes #83

This PR replaces a previous one that unintentionally included unrelated commits.