### PR TITLE
Add Test Cases to CommandResultTest

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,15 +118,15 @@ Examples:
 
 Finds persons whose **name**, **rate**, or **subject** match the given keyword.
 
-Format: `find n/NAME_KEYWORD [MORE_NAME_KEYWORDS]`  
-Format: `find r/RATE`  
+Format: `find n/NAME_KEYWORD [MORE_NAME_KEYWORDS]`
+Format: `find r/RATE`
 Format: `find s/SUBJECT`
 
 * The search is case-insensitive. e.g `n/hans` will match `Hans`
 * The order of the name keywords does not matter. e.g `n/Hans Bo` will match `Bo Hans`
 * Only full words will be matched for names e.g `n/Han` will not match `Hans`
 * Spaces after the prefix are optional. e.g. `n/Victoria` and `n/ Victoria` both work
-* Persons matching at least one name keyword will be returned (i.e. `OR` search).  
+* Persons matching at least one name keyword will be returned (i.e. `OR` search).
   e.g `n/Hans Bo` will return `Hans Gruber`, `Bo Yang`
 * Rate searches match persons whose rate is exactly the given value.
 * Subject searches match persons who have the specified subject.

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TestUtil.pairOf;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,7 +12,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import static seedu.address.testutil.TestUtil.pairOf;
+
 
 public class CommandResultTest {
     @Test
@@ -78,14 +79,14 @@ public class CommandResultTest {
     }
 
     @Test
-    public void isShowHelp_and_isExit_defaultFalse() {
+    public void showHelpExit_defaultFalse() {
         CommandResult commandResult = new CommandResult("feedback");
         assertFalse(commandResult.isShowHelp());
         assertFalse(commandResult.isExit());
     }
 
     @Test
-    public void isShowHelp_and_isExit_trueWhenSet() {
+    public void showHelpExit_trueWhenSet() {
         CommandResult commandResult = new CommandResult("feedback", true, true);
         assertTrue(commandResult.isShowHelp());
         assertTrue(commandResult.isExit());
@@ -129,5 +130,4 @@ public class CommandResultTest {
         assertTrue(s.contains(cr.getFeedbackToUser()));
         assertTrue(s.contains("Eve"));
     }
-    
 }

--- a/src/test/java/seedu/address/logic/commands/PersonIndexPairTest.java
+++ b/src/test/java/seedu/address/logic/commands/PersonIndexPairTest.java
@@ -3,11 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TestUtil.makePerson;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.Person;
-import static seedu.address.testutil.TestUtil.makePerson;
 import seedu.address.testutil.PersonBuilder;
 
 public class PersonIndexPairTest {

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -6,10 +6,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-import seedu.address.testutil.PersonBuilder;
-import seedu.address.logic.commands.CommandResult;
 
 /**
  * A utility class for test cases.


### PR DESCRIPTION
Previously, CommandResult was modified to support new features but test cases were not included for it. PersonIndexPair also lacked test cases

Adding test cases help to ensure that bugs are caught in automated testing

fixes #87 