### PR TITLE
Update build.gradle to allow assertions to run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,12 @@ shadowJar {
     archiveFileName = 'tuto.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
+test {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Previously, assertions were not allowed to be run

Updating build.gradle ensures assertions to catch unintended development errors

Fixes #110
