### PR TITLE
Fix Prefix Searching of multiple names

### DIFF
--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -30,7 +30,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
         String fullName = getPersonFullName(person);
 
-        return matchesAll(fullName);
+        return matchesAny(fullName);
     }
 
     private boolean isKeywordsEmpty() {
@@ -41,9 +41,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         return person.getName().fullName;
     }
 
-    private boolean matchesAll(String fullName) {
+    private boolean matchesAny(String fullName) {
         return keywords.stream()
-                .allMatch(keyword -> matchesKeyword(fullName, keyword));
+                .anyMatch(keyword -> matchesKeyword(fullName, keyword));
     }
 
     private boolean matchesKeyword(String fullName, String keyword) {

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -193,18 +193,19 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_hybridNameLogic_returnsCorrectFindCommand() throws Exception {
-        // Universal Search + Name -> Exclusive (AND) Logic for name keywords
+        // Universal Search + Name -> Inclusive (OR) Logic for name keywords
         String preamble = "keyword";
         FindCommand command = parser.parse(preamble + " n/Alice Pauline");
 
         Person alicePauline = personWithNameAndRate("Alice Pauline", "25");
         Person aliceTan = personWithNameAndRate("Alice Tan", "25");
         Person paulineLim = personWithNameAndRate("Pauline Lim", "25");
+        Person bobChoo = personWithNameAndRate("Bob Choo", "25");
 
         command = parser.parse(" 25 n/Alice Pauline");
 
-        assertMatch(command, alicePauline);
-        assertNoMatch(command, aliceTan, paulineLim);
+        assertMatch(command, alicePauline, aliceTan, paulineLim);
+        assertNoMatch(command, bobChoo);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -45,12 +45,16 @@ public class NameContainsKeywordsPredicateTest {
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Multiple keywords (AND)
+        // Multiple keywords (OR)
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Only one matching keyword (OR)
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
@@ -62,10 +66,6 @@ public class NameContainsKeywordsPredicateTest {
 
         // Non-matching keyword
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
-
-        // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name


### PR DESCRIPTION
Previously, the User Guide described the behaviour of searching for multiple names as FIND N/NAME [MORE NAMES]. However, after implementing Prefix Searching, this behaviour no longer exists

Fixing Prefix Searching for multiple names bring convenience to users while adhering to previously defined behaviour

Let's update to fix the logic

Fixes #155
