### PR TITLE
Fix UG Inconsistencies 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -209,7 +209,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL s/SUBJECT1 s/SUBJECT2 ... s/SUBJECTn 
 | `e/` | Email             | Yes       | Valid email format (e.g. `user@example.com`)                            |
 | `a/` | Address           | No        | Any text                                                                |
 | `s/` | Subject           | Yes       | Only Alphnumeric Text + Spaces (e.g. `Advanced Mathematics`, `Biology`) |
-| `r/` | Hourly rate (SGD) | Yes       | Positive number (Including Zero)                                        |
+| `r/` | Hourly rate (SGD) | Yes       | Positive Integer Value (Including Zero)                                 |
 | `t/` | Tag               | No        | Alphanumeric, no spaces                                                 |
 
 <box type="tip" seamless>


### PR DESCRIPTION
- expanded the `find` section with missing prefixes, search modes, matching rules, examples, and invalid usage
- clarified accepted values and duplicate constraints for `add` and `edit`
- corrected where tutor indices are shown and how indices change after `sort` and `delete`
- added or cleaned up command details for `help`, `list`, `delete`, and `exit`
- corrected the saved data file location to `data/addressbook.json`
- fixed minor formatting, wording, and table of contents issues throughout the guide