### PR TITLE
Disable WrapText and Enable textOverrun

### DIFF
--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -11,8 +11,8 @@
   <TextArea fx:id="resultDisplay" editable="false" wrapText="true" styleClass="result-display" minHeight="0"/>
     <VBox fx:id="resultListContainer" styleClass="result-display"
           visible="false" spacing="20" minHeight="0">
-        <Label fx:id="resultDescriptionDisplay" wrapText="true"
-               styleClass="result-description-label"
+        <Label fx:id="resultDescriptionDisplay" wrapText="false"
+               styleClass="result-description-label" textOverrun="ELLIPSIS"
                maxWidth="Infinity" minHeight="-Infinity"/>
         <ListView fx:id="resultListView" VBox.vgrow="ALWAYS" minHeight="0"/>
     </VBox>


### PR DESCRIPTION
Previously, when a long string is used to search, the query bar could expand and cover the whole result output

Disabling wraptext for straightforward truncation with ellipsis is a quick fix for this problem

Fixes #189 

Before
<img width="1278" height="812" alt="Screenshot 2026-04-07 at 12 50 09 PM" src="https://github.com/user-attachments/assets/5686cee6-8fce-4296-9901-5946c9902f04" />

After

<img width="1278" height="812" alt="Screenshot 2026-04-07 at 1 12 37 PM" src="https://github.com/user-attachments/assets/6d2676dc-048a-4d26-8616-687d60f5047b" />
