### PR TITLE
Fix Subject,Tag different case issue and allow international phone number 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -316,6 +316,15 @@ This ensures that phone number conflict is detected first, followed by email add
     - Pros: Serves as a reminder to user to record address of tutor in cases where face-to-face tuition is arranged
     - Cons: Does not account for the case where tuition may be done online and hence tutor's address is not needed
 
+**Aspect: Phone number must either be 8 digits for Singapore number or 10 digits excluding '+' for international number**
+
+- **Alternative 1 (current choice):** Phone number field must either be 8 digits for Singapore number or 10 digits excluding '+' for international number
+    - Pros: Accounts for the case where tutor may only have international number (e.g. Tutor is from Malaysia)
+    - Cons: Feature may be rarely used in practice due to the small number of international tutors
+- **Alternative 2:** Phone number field follows the original implementation of at least 3 digits and no special characters
+    - Pros: Simple to implement, no changes required
+    - Cons: Does not account for the case where tutor may only have international number (e.g. Tutor is from Malaysia)
+  
 #### Class Diagram
 
 The following class diagram shows the key classes involved in enforcing uniqueness constraints,

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1010,7 +1010,7 @@ testers are expected to do more _exploratory_ testing.
 7. Prefix case sensitivity and preamble swallowing (Mistyping prefixes)
     1. Prerequisites: Ensure the contact list has at least one Tutor with the name "Alice".
     2. Test case: `find N/Alice`<br>
-       Expected: The text feedback area is hidden. Because `N/` (capitalized) is not recognized as the official name prefix, the parser safely swallows it as a generic keyword. The blue search query bar shows `All fields: "N/Alice"`. Below it, the result list will show `No tutors found.` (unless a tutor profile literally contains "N/Alice").
+       Expected: The text feedback area is hidden. Because `N/` (capitalized) is not recognized as the official name prefix, the parser treats it as a generic keyword instead The blue search query bar shows `All fields: "N/Alice"`. Below it, the result list will show `No tutors found.` (unless a tutor profile literally contains "N/Alice").
 8. Regex and Special Character injection attempts
     1. Prerequisites: Tuto is running.
     2. Test case: `find *[a-z]+* ?.* {}`<br>
@@ -1022,7 +1022,7 @@ testers are expected to do more _exploratory_ testing.
 10. Backward slashes and parser confusion techniques
     1. Prerequisites: Tuto is running.
     2. Test case: `find /n Alice /s Math \t friend`<br>
-       Expected: No search is performed. The system strictly expects `n/`, `s/`, etc. as prefixes and subject should only be alphanumeric. Since the slashes are inverted or prefixed, the parser safely swallows it as a generic keyword. The blue search query bar shows `All fields: "/n Alice /s Math \t friend"`. Below it, the result list will show tutor records that contains parts of the search keywords.
+       Expected: No search is performed. The system strictly expects `n/`, `s/`, etc. as prefixes and subject should only be alphanumeric. Since the slashes are inverted or prefixed, the parser treats it as a generic keyword. The blue search query bar shows `All fields: "/n Alice /s Math \t friend"`. Below it, the result list will show tutor records that contains parts of the search keywords.
 11. Empty prefix values injected before valid constraints (Syntax gap traps)
     1. Prerequisites: Tuto is running.
     2. Test case: `find n/ s/Math r/50`<br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,7 +87,7 @@ Move the file into a dedicated folder (e.g. `~/tuto/`). This folder will store y
     ```
     cd ~/tuto
     ```
-3. Run the application:
+3. Input the following command to the terminal to start the application:
     ```
     java -jar tuto.jar
     ```
@@ -125,7 +125,7 @@ Type a command into the **Command Box** at the bottom and press **Enter** to run
 Tuto's interface has three main areas:
 
 - **Tutor List Panel (Left)** — shows all Tutor Profiles saved
-- **Result Display (Top Right)** — shows feedback after each command (success or error messages, records retrieved searching)
+- **Result Display (Top Right)** — shows feedback after each command (success or error messages and records retrieved from searches)
 - **Command Box (Bottom Right)** — where you type your commands
 
 Each tutor card in the panel shows the tutor's name, phone number, email, subject, and hourly rate. Tags (if any) appear as labels on the card.
@@ -220,15 +220,15 @@ Adds a new Tutor Profile to Tuto.
 
 #### Parameters
 
-| Prefix | Field             | Required | Accepted values                                                                 |
-| ------ | ----------------- | -------- |---------------------------------------------------------------------------------|
-| `n/`   | Name              | Yes      | Alphanumeric text + spaces                                                      |
-| `p/`   | Phone number      | Yes      | 8 digits for Singapore number, 10 digits excluding '+' for international number |
-| `e/`   | Email             | Yes      | Valid email format (e.g. `user@example.com`)                                    |
-| `s/`   | Subject           | Yes      | Alphanumeric text + spaces (e.g. `Advanced Mathematics`, `Biology`)             |
-| `r/`   | Hourly rate (SGD) | Yes      | 0 or any positive integer                                                       |
-| `a/`   | Address           | No       | Any text                                                                        |
-| `t/`   | Tag               | No       | Alphanumeric text, no spaces                                                    |
+| Prefix | Field             | Required | Accepted values                                                                                        |
+| ------ | ----------------- | -------- |--------------------------------------------------------------------------------------------------------|
+| `n/`   | Name              | Yes      | Alphanumeric text + spaces allowed only, no special characters are allowed                             |
+| `p/`   | Phone number      | Yes      | 8 digits for Singapore number, 10 digits excluding '+' for international number                        |
+| `e/`   | Email             | Yes      | Valid email format (e.g. `user@example.com`)                                                           |
+| `s/`   | Subject           | Yes      | Alphanumeric text + spaces (e.g. `Advanced Mathematics`, `Biology`)                                    |
+| `r/`   | Hourly rate (SGD) | Yes      | 0 or any positive integer                                                                              |
+| `a/`   | Address           | No       | Any text (must not contain valid prefixes such as s/, as these will be interpreted as separate fields) |
+| `t/`   | Tag               | No       | Alphanumeric text, no spaces                                                                           |
 
 <box type="tip" seamless>
 
@@ -686,22 +686,17 @@ When `exit` executes successfully, Tuto closes. Tutor data is saved automaticall
 Tuto's data are saved automatically as a JSON file `[JAR file location]/data/addressbook.json`. Advanced users are welcome to update data directly by editing that data file.
 
 <box type="warning" seamless>
-
-**Caution:**
-If your changes to the data file makes its format invalid, Tuto will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
-Furthermore, certain edits can cause Tuto to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+**Caution:** If the file is saved in an invalid format, Tuto will discard all data and start fresh on the next launch. **Back up the file before making any edits.** Additionally, values outside accepted ranges may cause Tuto to behave unexpectedly.
 </box>
-
----
 
 ### Editing the Data File Directly
 
 Advanced users may edit the data file manually using any text editor.
 
 <box type="warning" seamless>
+**Caution:** If your changes to the data file make its format invalid, Tuto will discard all data and start with an empty data file on the next launch. Back up the file before editing it.
 
-**Caution:** If the file is saved in an invalid format, Tuto will discard all data and start fresh on the next launch. **Back up the file before making any edits.** Additionally, values outside accepted ranges may cause Tuto to behave unexpectedly.
-
+Furthermore, certain edits can cause Tuto to behave in unexpected ways (e.g., if a value is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </box>
 
 ---
@@ -735,14 +730,14 @@ A: The Help Window may be minimised. Check your taskbar and restore it manually.
 
 ## Command Summary
 
-| Action     | Format                                                                                                | Example                                                                                                           |
-| ---------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Help**   | `help`                                                                                                | `help`                                                                                                            |
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL s/SUBJECT1 s/SUBJECT2 ... s/SUBJECTn r/RATE [a/ADDRESS] [t/TAG]…​` | `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 s/Biology r/45 t/friend t/colleague` |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]… [r/RATE] [t/TAG]…`                  | `edit 2 n/James Lee e/james@example.com`                                                                          |
-| **Delete** | `delete INDEX`                                                                                        | `delete 3`                                                                                                        |
-| **Find**   | `find KEYWORD` \| `find [PREFIXES]` \| `find KEYWORD [PREFIXES]`                                      | `find geography`, `find s/Biology r/45`, `find korean r/>50`                                                      |
-| **Sort**   | `sort FIELD ORDER`                                                                                    | `sort name asc`, `sort rate desc`                                                                                 |
-| **List**   | `list`                                                                                                | `list`                                                                                                            |
-| **Clear**  | `clear`                                                                                               | `clear`                                                                                                           |
-| **Exit**   | `exit`                                                                                                | `exit`                                                                                                            |
+| Action     | Format                                                                                                | Example                                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------|
+| **Help**   | `help`                                                                                                | `help`                                                                                                               |
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL s/SUBJECT1 s/SUBJECT2 ... s/SUBJECTn r/RATE [a/ADDRESS] [t/TAG]…​` | `add n/James Ho p/+6512345678 e/jamesho@example.com a/123, Clementi Rd, 1234665 s/Biology r/45 t/friend t/colleague` |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SUBJECT]… [r/RATE] [t/TAG]…`                  | `edit 2 n/James Lee e/james@example.com`                                                                             |
+| **Delete** | `delete INDEX`                                                                                        | `delete 3`                                                                                                           |
+| **Find**   | `find KEYWORD` \| `find [PREFIXES]` \| `find KEYWORD [PREFIXES]`                                      | `find geography`, `find s/Biology r/45`, `find korean r/>50`                                                         |
+| **Sort**   | `sort FIELD ORDER`                                                                                    | `sort name asc`, `sort rate desc`                                                                                    |
+| **List**   | `list`                                                                                                | `list`                                                                                                               |
+| **Clear**  | `clear`                                                                                               | `clear`                                                                                                              |
+| **Exit**   | `exit`                                                                                                | `exit`                                                                                                               |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -237,8 +237,8 @@ Adds a new Tutor Profile to Tuto.
 1. Tags are powerful ways to organise Tutor Profiles. You can use multiple tags to provide more detail, e.g. `t/home` and `t/weekend`.
 2. A person can have any number of tags (including 0) and multiple subjects.
 3. Command parameters can be entered in any order.
-4. You cannot repeat the same subject or tag value in one command (e.g. s/Math s/Math or t/friend t/friend is rejected).
-
+4. You cannot repeat the same subject or tag value in one command, even if the casing is different (e.g. s/Math s/math or t/friend t/friend is rejected).
+5. Rate can only be positive integer. No decimal values are allowed.
 </box>
 
 ---

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -220,15 +220,15 @@ Adds a new Tutor Profile to Tuto.
 
 #### Parameters
 
-| Prefix | Field             | Required | Accepted values                                                     |
-| ------ | ----------------- | -------- | ------------------------------------------------------------------- |
-| `n/`   | Name              | Yes      | Alphanumeric text + spaces                                          |
-| `p/`   | Phone number      | Yes      | Digits only, at least 3 digits                                      |
-| `e/`   | Email             | Yes      | Valid email format (e.g. `user@example.com`)                        |
-| `s/`   | Subject           | Yes      | Alphanumeric text + spaces (e.g. `Advanced Mathematics`, `Biology`) |
-| `r/`   | Hourly rate (SGD) | Yes      | 0 or any positive integer                                           |
-| `a/`   | Address           | No       | Any text                                                            |
-| `t/`   | Tag               | No       | Alphanumeric text, no spaces                                        |
+| Prefix | Field             | Required | Accepted values                                                                 |
+| ------ | ----------------- | -------- |---------------------------------------------------------------------------------|
+| `n/`   | Name              | Yes      | Alphanumeric text + spaces                                                      |
+| `p/`   | Phone number      | Yes      | 8 digits for Singapore number, 10 digits excluding '+' for international number |
+| `e/`   | Email             | Yes      | Valid email format (e.g. `user@example.com`)                                    |
+| `s/`   | Subject           | Yes      | Alphanumeric text + spaces (e.g. `Advanced Mathematics`, `Biology`)             |
+| `r/`   | Hourly rate (SGD) | Yes      | 0 or any positive integer                                                       |
+| `a/`   | Address           | No       | Any text                                                                        |
+| `t/`   | Tag               | No       | Alphanumeric text, no spaces                                                    |
 
 <box type="tip" seamless>
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -67,7 +67,13 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
-        if (!Phone.isValidPhone(trimmedPhone)) {
+        String normalisedPhone;
+        if (trimmedPhone.matches("\\d{8}")) {
+            normalisedPhone = "+65" + trimmedPhone;
+        } else {
+            normalisedPhone = trimmedPhone;
+        }
+        if (!Phone.isValidPhone(normalisedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -61,7 +61,7 @@ public class Address {
         }
 
         Address otherAddress = (Address) other;
-        return value.equals(otherAddress.value);
+        return value.equalsIgnoreCase(otherAddress.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -75,7 +75,7 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,11 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers must either: \n"
+            + "1. Be 8 digits (will default to +65), OR \n"
+            + "2. Start with '+' followed up by 10 digits.";
+    private static final String DIGIT_REGEX = "\\d{8}";
+    private static String INTERNATIONAL_REGEX = "\\+\\d+";
     public final String value;
 
     /**
@@ -22,15 +25,27 @@ public class Phone {
      */
     public Phone(String phone) {
         requireNonNull(phone);
-        checkArgument(isValidPhone(phone), MESSAGE_CONSTRAINTS);
-        value = phone;
+        String localisedNumber = localise(phone);
+        checkArgument(isValidPhone(localisedNumber), MESSAGE_CONSTRAINTS);
+        value = localisedNumber;
     }
 
+    private static String localise(String input) {
+        if (input.matches(DIGIT_REGEX)) {
+            return "+65" + input;
+        }
+        return input;
+    }
     /**
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (!test.matches(INTERNATIONAL_REGEX)) {
+            return false;
+        }
+
+        String digits = test.substring(1);
+        return digits.length() == 10;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -15,7 +15,7 @@ public class Phone {
             + "1. Be 8 digits (will default to +65), OR \n"
             + "2. Start with '+' followed up by 10 digits.";
     private static final String DIGIT_REGEX = "\\d{8}";
-    private static String INTERNATIONAL_REGEX = "\\+\\d+";
+    private static final String international_regex = "\\+\\d+";
     public final String value;
 
     /**
@@ -40,7 +40,7 @@ public class Phone {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        if (!test.matches(INTERNATIONAL_REGEX)) {
+        if (!test.matches(international_regex)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/model/person/Subject.java
+++ b/src/main/java/seedu/address/model/person/Subject.java
@@ -28,8 +28,9 @@ public class Subject {
      */
     public Subject(String subject) {
         requireNonNull(subject);
-        checkArgument(isValidSubject(subject), MESSAGE_CONSTRAINTS);
-        this.subject = subject;
+        String trimmed = subject.trim();
+        checkArgument(isValidSubject(trimmed), MESSAGE_CONSTRAINTS);
+        this.subject = trimmed;
     }
 
     /**
@@ -56,12 +57,12 @@ public class Subject {
         }
 
         Subject otherSubject = (Subject) other;
-        return subject.equals(otherSubject.subject);
+        return subject.equalsIgnoreCase(otherSubject.subject);
     }
 
     @Override
     public int hashCode() {
-        return subject.hashCode();
+        return subject.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -21,8 +21,9 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        String trimmed = tagName.trim();
+        checkArgument(isValidTagName(trimmed), MESSAGE_CONSTRAINTS);
+        this.tagName = trimmed;
     }
 
     /**
@@ -44,12 +45,12 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        return tagName.equalsIgnoreCase(otherTag.tagName);
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toLowerCase().hashCode();
     }
 
     /**

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Valid Person",
-    "phone": "9482424",
+    "phone": "+6594824242",
     "email": "hans@example.com",
     "address": "4th street"
   }, {

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -1,7 +1,7 @@
 {
   "persons": [ {
     "name": "Alice Pauline",
-    "phone": "94351253",
+    "phone": "+6594351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
     "subject": [ "Math" ],
@@ -9,7 +9,7 @@
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
-    "phone": "94351253",
+    "phone": "+6594351253",
     "email": "pauline@example.com",
     "address": "4th street",
     "subject":[ "Math" ],

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -2,7 +2,7 @@
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
   "persons" : [ {
     "name" : "Alice Pauline",
-    "phone" : "94351253",
+    "phone" : "+6594351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "subjects" : [ "Math" ],
@@ -10,7 +10,7 @@
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
-    "phone" : "98765432",
+    "phone" : "+6598765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "subjects" : [ "English" ],
@@ -18,7 +18,7 @@
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
-    "phone" : "95352563",
+    "phone" : "+6095352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
     "subjects" : [ "Physics" ],
@@ -26,7 +26,7 @@
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
-    "phone" : "87652533",
+    "phone" : "+6587652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
     "subjects" : [ "Chemistry" ],
@@ -34,7 +34,7 @@
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "+6294882224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "subjects" : [ "Biology" ],
@@ -42,7 +42,7 @@
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "+6194828427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "subjects" : [ "History" ],
@@ -50,7 +50,7 @@
     "tags" : [ ]
   }, {
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "+6594882442",
     "email" : "anna@example.com",
     "address" : "4th street",
     "subjects" : [ "Geography" ],

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,8 +30,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "+6511111111";
+    public static final String VALID_PHONE_BOB = "+6522222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "+6512345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -69,9 +69,10 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("+6512345678",
+                "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(
-                new PersonBuilder().withName("Alice").withPhone("12345")
+                new PersonBuilder().withName("Alice").withPhone("+6512345678")
                         .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -33,17 +33,16 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("+6512345678")); // exactly 10 numbers with Singapore number
+        assertTrue(Phone.isValidPhone("+6012345678")); // International number
     }
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("+6512345678");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertTrue(phone.equals(new Phone("+6512345678")));
 
         // same object -> returns true
         assertTrue(phone.equals(phone));
@@ -55,6 +54,6 @@ public class PhoneTest {
         assertFalse(phone.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertFalse(phone.equals(new Phone("+6012345678")));
     }
 }

--- a/src/test/java/seedu/address/model/person/SubjectEqualsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/SubjectEqualsPredicateTest.java
@@ -58,7 +58,7 @@ public class SubjectEqualsPredicateTest {
         // person has Biology and Math
         Person person = new PersonBuilder().withSubject("Biology").withName("Bob").build();
         // PersonBuilder.withSubject replaces the subject set; to create multiple subjects use SampleDataUtil
-        Person multi = new Person(new Name("Bob"), new Phone("123"), new Email("a@b.com"), new Address("addr"),
+        Person multi = new Person(new Name("Bob"), new Phone("+6512345678"), new Email("a@b.com"), new Address("addr"),
                 SampleDataUtil.getSubjectSet("Biology", "Math"), new Rate("10"), Collections.emptySet());
 
         SubjectEqualsPredicate predicate = new SubjectEqualsPredicate(Collections.singleton(new Subject("Bio")));
@@ -113,11 +113,11 @@ public class SubjectEqualsPredicateTest {
     }
 
     @Test
-    public void equals_trailingSpaceDifference_false() {
+    public void equals_trailingSpaceDifference_true() {
         // Subject accepts internal/trailing spaces; equality should be sensitive to the actual string
         SubjectEqualsPredicate p1 = new SubjectEqualsPredicate(Collections.singleton(new Subject("Biology")));
         SubjectEqualsPredicate p2 = new SubjectEqualsPredicate(Collections.singleton(new Subject("Biology ")));
-        assertFalse(p1.equals(p2));
+        assertTrue(p1.equals(p2));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniversalSearchPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/UniversalSearchPredicateTest.java
@@ -45,7 +45,7 @@ public class UniversalSearchPredicateTest {
         assertMatch("Ali", new PersonBuilder().withName("Alice Bob").build());
 
         // Phone match (prefix)
-        assertMatch("123", new PersonBuilder().withPhone("12345").build());
+        assertMatch("+6512345678", new PersonBuilder().withPhone("+6512345678").build());
 
         // Email match (prefix)
         assertMatch("ali", new PersonBuilder().withEmail("alice@example.com").build());

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -19,7 +19,7 @@ import seedu.address.model.util.SampleDataUtil;
 public class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Bee";
-    public static final String DEFAULT_PHONE = "85355255";
+    public static final String DEFAULT_PHONE = "+6585355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_SUBJECT = "Math";

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,34 +26,34 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withPhone("+6594351253")
             .withSubject("Math").withRate("25")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withPhone("+6598765432")
             .withSubject("English").withRate("100")
             .withTags("owesMoney", "friends").build();
-    public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
+    public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("+6095352563")
             .withEmail("heinz@example.com").withAddress("wall street")
             .withSubject("Physics").withRate("30").build();
-    public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
+    public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("+6587652533")
             .withEmail("cornelia@example.com").withAddress("10th street")
             .withSubject("Chemistry").withRate("40").withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("+6294882224")
             .withEmail("werner@example.com").withAddress("michegan ave")
             .withSubject("Biology").withRate("50").build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("+6194828427")
             .withEmail("lydia@example.com").withAddress("little tokyo")
             .withSubject("History").withRate("60").build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("+6594882442")
             .withEmail("anna@example.com").withAddress("4th street")
             .withSubject("Geography").withRate("70").build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("+6588482424")
             .withEmail("stefan@example.com").withAddress("little india").build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("+6084828131")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Closes #227, #232, #235, #237, #240, #242, #245, #250, #255, #265, #268, #271, #279, #284, #285

Updated User and developer guide for minor grammatical and readability issue
Updated Subject, Tag and Address to detect duplicates even if the casing is different
Updated Phone number to allow either 8 digits that will default to as Singapore number or 10 digits with "+" for international number
